### PR TITLE
Optimize memory-allocations a bit here and there

### DIFF
--- a/griblib/bitreader.go
+++ b/griblib/bitreader.go
@@ -81,7 +81,7 @@ func (r *BitReader) readInt(nbits int) (int64, error) {
 }
 
 func (r *BitReader) readUintsBlock(bits int, count int64, resetOffset bool) ([]uint64, error) {
-	result := []uint64{}
+	result := make([]uint64, count)
 
 	if resetOffset {
 		r.resetOffset()
@@ -93,7 +93,7 @@ func (r *BitReader) readUintsBlock(bits int, count int64, resetOffset bool) ([]u
 			if err != nil {
 				return result, err
 			}
-			result = append(result, data)
+			result[i] = data
 		}
 	}
 
@@ -101,7 +101,7 @@ func (r *BitReader) readUintsBlock(bits int, count int64, resetOffset bool) ([]u
 }
 
 func (r *BitReader) readIntsBlock(bits int, count int64, resetOffset bool) ([]int64, error) {
-	result := []int64{}
+	result := make([]int64, count)
 
 	if resetOffset {
 		r.resetOffset()
@@ -113,7 +113,7 @@ func (r *BitReader) readIntsBlock(bits int, count int64, resetOffset bool) ([]in
 			if err != nil {
 				return result, err
 			}
-			result = append(result, int64(data))
+			result[i] = int64(data)
 		}
 	}
 

--- a/griblib/data2.go
+++ b/griblib/data2.go
@@ -74,15 +74,15 @@ func (template *Data2) missingValueSubstitute() (float64, float64) {
 }
 
 func (template *Data2) scaleValues(section7Data []int64, ifldmiss []int64) []float64 {
-	fld := []float64{}
+	fld := make([]float64, len(section7Data))
 
 	scaleStrategy := template.scaleFunc()
 	missingValueSubstitute1, missingValueSubstitute2 := template.missingValueSubstitute()
 
 	if template.MissingValue == 0 {
 		// no missing values
-		for _, dataValue := range section7Data {
-			fld = append(fld, scaleStrategy(dataValue))
+		for n, dataValue := range section7Data {
+			fld[n] = scaleStrategy(dataValue)
 		}
 	}
 	if template.MissingValue == 1 || template.MissingValue == 2 {
@@ -90,11 +90,11 @@ func (template *Data2) scaleValues(section7Data []int64, ifldmiss []int64) []flo
 		for n, dataValue := range section7Data {
 			switch ifldmiss[n] {
 			case 0:
-				fld = append(fld, scaleStrategy(dataValue))
+				fld[n] = scaleStrategy(dataValue)
 			case 1:
-				fld = append(fld, missingValueSubstitute1)
+				fld[n] = missingValueSubstitute1
 			case 2:
-				fld = append(fld, missingValueSubstitute2)
+				fld[n] = missingValueSubstitute2
 			}
 		}
 	}
@@ -103,9 +103,9 @@ func (template *Data2) scaleValues(section7Data []int64, ifldmiss []int64) []flo
 }
 
 func (template *Data2) extractData(bitReader *BitReader, bitGroups []bitGroupParameter) ([]int64, []int64, error) {
-	section7Data := []int64{}
-	ifldmiss := []int64{}
-
+	// TODO : read 1 bitgroup at a time to a fixed-size slice, append each slice to a master-slice
+	section7Data := make([]int64, 0)
+	ifldmiss := make([]int64, 0)
 	for _, bitGroup := range bitGroups {
 		tmp, err := bitGroup.readData(bitReader)
 		if err != nil {

--- a/griblib/gribtest/Makefile
+++ b/griblib/gribtest/Makefile
@@ -1,3 +1,5 @@
+.PHONY: default benchmark
+
 default:
 	go test -v 
 

--- a/griblib/gribtest/performance_test.go
+++ b/griblib/gribtest/performance_test.go
@@ -10,12 +10,11 @@ import (
 func BenchmarkReadMessages(b *testing.B) {
 	// run the Fib function b.N times
 
-	f, err := os.Open("../integrationtestdata/template5_3.grib2")
-	if err != nil {
-		b.Fatalf("Could not open test-file %v", err)
-	}
-
 	for n := 0; n < b.N; n++ {
+		f, err := os.Open("../integrationtestdata/template5_3.grib2")
+		if err != nil {
+			b.Fatalf("Could not open test-file %v", err)
+		}
 		griblib.ReadMessages(f)
 	}
 }


### PR DESCRIPTION
# Old performance-test results:

```
go tool pprof -top memprofile.out
File: gribtest.test
Type: alloc_space
Time: Feb 7, 2019 at 10:25pm (CET)
Showing nodes accounting for 9.66GB, 99.32% of 9.73GB total
Dropped 44 nodes (cum <= 0.05GB)
      flat  flat%   sum%        cum   cum%
    4.78GB 49.20% 49.20%     5.87GB 60.31%  github.com/nilsmagnus/grib/griblib.(*Data2).extractData
    2.36GB 24.26% 73.46%     2.36GB 24.26%  github.com/nilsmagnus/grib/griblib.(*Data2).scaleValues
    0.95GB  9.78% 83.24%     0.95GB  9.78%  github.com/nilsmagnus/grib/griblib.(*BitReader).readIntsBlock
    0.65GB  6.71% 89.95%     9.71GB 99.84%  github.com/nilsmagnus/grib/griblib.ReadMessage
    0.26GB  2.63% 92.58%     0.26GB  2.63%  github.com/nilsmagnus/grib/griblib.(*BitReader).readUintsBlock
    0.25GB  2.61% 95.19%     0.50GB  5.17%  github.com/nilsmagnus/grib/griblib.(*Data2).extractBitGroupParameters
    0.13GB  1.34% 96.52%     0.13GB  1.34%  github.com/nilsmagnus/grib/griblib.bitGroupParameter.zeroGroup
    0.10GB     1% 97.52%     0.10GB     1%  reflect.(*structType).Field
    0.09GB  0.87% 98.40%     0.18GB  1.86%  encoding/binary.Read
    0.04GB  0.46% 98.86%     0.18GB  1.82%  github.com/nilsmagnus/grib/griblib.ReadSection0
    0.04GB  0.46% 99.32%     8.88GB 91.30%  github.com/nilsmagnus/grib/griblib.readMessage
         0     0% 99.32%     0.10GB     1%  encoding/binary.dataSize
         0     0% 99.32%     0.10GB     1%  encoding/binary.sizeof
         0     0% 99.32%     0.09GB  0.93%  github.com/nilsmagnus/grib/griblib.(*Data2).extractGroupBitWidths
         0     0% 99.32%     0.08GB  0.78%  github.com/nilsmagnus/grib/griblib.(*Data2).extractGroupLengths
         0     0% 99.32%     0.08GB  0.85%  github.com/nilsmagnus/grib/griblib.(*Data2).extractGroupReferences
         0     0% 99.32%     8.75GB 90.00%  github.com/nilsmagnus/grib/griblib.ParseData3
         0     0% 99.32%     9.71GB 99.84%  github.com/nilsmagnus/grib/griblib.ReadMessages
         0     0% 99.32%     8.78GB 90.31%  github.com/nilsmagnus/grib/griblib.ReadSection7
         0     0% 99.32%     1.08GB 11.12%  github.com/nilsmagnus/grib/griblib.bitGroupParameter.readData
         0     0% 99.32%     0.89GB  9.16%  github.com/nilsmagnus/grib/griblib/gribtest.BenchmarkReadMessages
         0     0% 99.32%     0.55GB  5.66%  github.com/nilsmagnus/grib/griblib/gribtest.Test_message_to_png
         0     0% 99.32%     3.86GB 39.72%  github.com/nilsmagnus/grib/griblib/gribtest.Test_read_integrationtest_file
         0     0% 99.32%     3.81GB 39.18%  github.com/nilsmagnus/grib/griblib/gribtest.Test_read_integrationtest_file_hour0
         0     0% 99.32%     0.55GB  5.62%  github.com/nilsmagnus/grib/griblib/gribtest.Test_temperature_layers
         0     0% 99.32%     0.10GB     1%  reflect.(*rtype).Field
         0     0% 99.32%     0.87GB  8.94%  testing.(*B).launch
         0     0% 99.32%     0.89GB  9.16%  testing.(*B).runN
         0     0% 99.32%     8.83GB 90.82%  testing.tRunner
```

# New performance-test results:

```
go tool pprof -top memprofile.out
File: gribtest.test
Type: alloc_space
Time: Feb 7, 2019 at 10:23pm (CET)
Showing nodes accounting for 7.82GB, 99.67% of 7.85GB total
Dropped 50 nodes (cum <= 0.04GB)
      flat  flat%   sum%        cum   cum%
    5.88GB 74.98% 74.98%     6.47GB 82.44%  github.com/nilsmagnus/grib/griblib.(*Data2).extractData
    0.75GB  9.51% 84.48%     0.75GB  9.51%  github.com/nilsmagnus/grib/griblib.(*Data2).scaleValues
    0.47GB  6.04% 90.53%     0.47GB  6.04%  github.com/nilsmagnus/grib/griblib.(*BitReader).readIntsBlock
    0.27GB  3.38% 93.91%     0.35GB  4.41%  github.com/nilsmagnus/grib/griblib.(*Data2).extractBitGroupParameters
    0.11GB  1.42% 95.32%     0.11GB  1.42%  github.com/nilsmagnus/grib/griblib.bitGroupParameter.zeroGroup
    0.08GB  1.05% 96.37%     0.08GB  1.05%  github.com/nilsmagnus/grib/griblib.(*BitReader).readUintsBlock
    0.07GB  0.94% 97.32%     7.83GB 99.80%  github.com/nilsmagnus/grib/griblib.ReadMessage
    0.06GB  0.82% 98.13%     0.06GB  0.82%  encoding/binary.Read
    0.06GB  0.78% 98.92%     0.06GB  0.79%  github.com/nilsmagnus/grib/griblib.makeBitReader
    0.06GB  0.75% 99.67%     7.76GB 98.86%  github.com/nilsmagnus/grib/griblib.readMessage
         0     0% 99.67%     7.61GB 96.98%  github.com/nilsmagnus/grib/griblib.ParseData3
         0     0% 99.67%     7.83GB 99.80%  github.com/nilsmagnus/grib/griblib.ReadMessages
         0     0% 99.67%     7.63GB 97.26%  github.com/nilsmagnus/grib/griblib.ReadSection7
         0     0% 99.67%     0.59GB  7.46%  github.com/nilsmagnus/grib/griblib.bitGroupParameter.readData
         0     0% 99.67%     1.56GB 19.90%  github.com/nilsmagnus/grib/griblib/gribtest.BenchmarkReadMessages
         0     0% 99.67%     0.37GB  4.70%  github.com/nilsmagnus/grib/griblib/gribtest.Test_message_to_png
         0     0% 99.67%     2.75GB 34.98%  github.com/nilsmagnus/grib/griblib/gribtest.Test_read_integrationtest_file
         0     0% 99.67%     2.72GB 34.72%  github.com/nilsmagnus/grib/griblib/gribtest.Test_read_integrationtest_file_hour0
         0     0% 99.67%     0.40GB  5.04%  github.com/nilsmagnus/grib/griblib/gribtest.Test_temperature_layers
         0     0% 99.67%     1.54GB 19.66%  testing.(*B).launch
         0     0% 99.67%     1.56GB 19.90%  testing.(*B).runN
         0     0% 99.67%     6.28GB 80.07%  testing.tRunner
rm profile.out memprofile.out
rm gribtest.test
```