### PR TITLE
Throw error when parsing invalid section0 indicator

### DIFF
--- a/griblib/sections.go
+++ b/griblib/sections.go
@@ -176,8 +176,10 @@ func ReadSection0(reader io.Reader) (section0 Section0, err error) {
 
 	if section0.Indicator == Grib {
 		if section0.Edition != SupportedGribEdition {
-			return section0, fmt.Errorf("Unsupported  grib edition %d", section0.Edition)
+			return section0, fmt.Errorf("Unsupported grib edition %d", section0.Edition)
 		}
+	} else {
+		return section0, fmt.Errorf("Unsupported grib indicator %d", section0.Indicator)
 	}
 
 	return


### PR DESCRIPTION
This pull request fixes the issue mentioned in #17 whereby invalid/arbitrary data would cause a panic. This change basically requires that section0's GRIB indicator be valid before allowing parsing to continue, throwing an error instead of panic-ing.

I've attached an [example file](https://github.com/nilsmagnus/grib/files/4185235/gfs.t18z.pgrb2.0p25.txt) from a NOAA.gov source that returned an HTML error page instead of the expected grib file, which caused the panic for us.

