### PR TITLE
fix wrong negative latitude & longitude

### DIFF
--- a/griblib/grids.go
+++ b/griblib/grids.go
@@ -7,6 +7,13 @@ import (
 	"io"
 )
 
+func fixNegLatLon(num int32) int32 {
+	if num < 0 {
+		return -int32(uint32(num) &^ uint32(0x80000000))
+	}
+	return num
+}
+
 //ScaledValue specifies the scale of a value
 type ScaledValue struct {
 	Scale uint8  `json:"scale"`
@@ -26,22 +33,45 @@ type Grid interface {
 
 //ReadGrid reads grid from binary input to the grid-number specified by templateNumber
 func ReadGrid(f io.Reader, templateNumber uint16) (Grid, error) {
+	var err error
+	var g Grid
 	switch templateNumber {
 	case 0:
 		var grid Grid0
-		return &grid, binary.Read(f, binary.BigEndian, &grid)
+		err = binary.Read(f, binary.BigEndian, &grid)
+		grid.La1 = fixNegLatLon(grid.La1)
+		grid.Lo1 = fixNegLatLon(grid.Lo1)
+		grid.La2 = fixNegLatLon(grid.La2)
+		grid.Lo2 = fixNegLatLon(grid.Lo2)
+		g = &grid
 	case 10:
 		var grid Grid10
-		return &grid, binary.Read(f, binary.BigEndian, &grid)
+		err = binary.Read(f, binary.BigEndian, &grid)
+		grid.La1 = fixNegLatLon(grid.La1)
+		grid.Lo1 = fixNegLatLon(grid.Lo1)
+		grid.La2 = fixNegLatLon(grid.La2)
+		grid.Lo2 = fixNegLatLon(grid.Lo2)
+		g = &grid
 	case 20:
 		var grid Grid20
-		return &grid, binary.Read(f, binary.BigEndian, &grid)
+		err = binary.Read(f, binary.BigEndian, &grid)
+		grid.La1 = fixNegLatLon(grid.La1)
+		grid.Lo1 = fixNegLatLon(grid.Lo1)
+		g = &grid
 	case 30:
 		var grid Grid30
-		return &grid, binary.Read(f, binary.BigEndian, &grid)
+		err = binary.Read(f, binary.BigEndian, &grid)
+		grid.La1 = fixNegLatLon(grid.La1)
+		grid.Lo1 = fixNegLatLon(grid.Lo1)
+		g = &grid
 	case 40:
 		var grid Grid40
-		return &grid, binary.Read(f, binary.BigEndian, &grid)
+		err = binary.Read(f, binary.BigEndian, &grid)
+		grid.La1 = fixNegLatLon(grid.La1)
+		grid.Lo1 = fixNegLatLon(grid.Lo1)
+		grid.La2 = fixNegLatLon(grid.La2)
+		grid.Lo2 = fixNegLatLon(grid.Lo2)
+		g = &grid
 	case 90:
 		var grid Grid90
 		return &grid, binary.Read(f, binary.BigEndian, &grid)
@@ -49,6 +79,7 @@ func ReadGrid(f io.Reader, templateNumber uint16) (Grid, error) {
 		var grid Grid90
 		return &grid, errors.New(fmt.Sprint("Unknown grid template number ", templateNumber))
 	}
+	return g, err
 }
 
 //GridHeader is a common header in all grids

--- a/griblib/grids.go
+++ b/griblib/grids.go
@@ -123,7 +123,7 @@ type Grid10 struct {
 type Grid20 struct {
 	//name =  "Polar stereographic projection ";
 	GridHeader
-	Nx                          uint32 `json:"Nx"`
+	Nx                          uint32 `json:"nx"`
 	Ny                          uint32 `json:"ny"`
 	La1                         int32  `json:"na1"`
 	Lo1                         int32  `json:"lo1"`


### PR DESCRIPTION
As the example in page 68:
https://www.wmo.int/pages/prog/www/WMOCodes/Guides/GRIB/GRIB2_062006.pdf
```
47-50 84-87 90000000 The latitude of the first grid point (La1) is –90.000000o. Bit 1 is set to 1 to indicate
 negative (south) latitude.
```
So, we should clear first bit and do negative again if it is negative.
Otherwise will get `-2057483648` when it should be `-90000000`.

ps. I'm trying to refactor for some grib2 file which may content multiple` (Section2 + Section3 + Section5 + Section6 + Section7)*N` or `(Section3 + (Section4 + Section5 + Section6 + Section7)*N)*M`